### PR TITLE
Use core::error::Error, remove std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base16"
 version = "0.2.1"
-rust-version = "1.60.0"
+rust-version = "1.81.0"
 authors = ["Thom Chiovoloni <chiovolonit@gmail.com>"]
 keywords = ["hex", "base16", "encode", "decode", "no_std"]
 repository = "https://github.com/thomcc/rust-base16"
@@ -18,7 +18,6 @@ members = ["benchmarks", "fuzz"]
 bench = false
 
 [features]
-std = ["alloc"]
 alloc = []
 default = ["alloc"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! [alloc_crate]: https://doc.rust-lang.org/alloc/index.html
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![deny(missing_docs)]
 
 #[cfg(feature = "alloc")]
@@ -435,8 +435,7 @@ impl core::fmt::Display for DecodeError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DecodeError {}
+impl core::error::Error for DecodeError {}
 
 #[inline]
 fn decode_slice_raw(src: &[u8], dst: &mut [MaybeUninit<u8>]) -> Result<(), usize> {


### PR DESCRIPTION
The error trait has been moved into core since rust 1.81, allowing this crate to not rely on std at all anymore.

This is a breaking change since it removes a feature and also bumps MSRV